### PR TITLE
Disable data_structure embedding in intGen.py, removal of "isList" codeblock from l4.yml

### DIFF
--- a/docassemble/l4/data/questions/l4.yml
+++ b/docassemble/l4/data/questions/l4.yml
@@ -155,28 +155,3 @@ script: |
     $(".dasingleselect").change(function(){this.form.submit()})
   </script>
 ---
-#mandatory: True
-#code: |
-  #def isList(agenda_item):
-    #substr = "[ijklmn]*[0-9]*"
-    #agenda_without_indices = re.sub("\[" + substr + "\]",'',agenda_item)
-    #for i, item in enumerate(agenda_without_indices):
-        #for var in data_structure:
-            #if item == var['name']:
-                #if i + 1 == len(agenda_without_indices):
-                    #if "exactly" in var and var["exactly"] > 1:
-                        #return True
-                    #if "minimum" in var:
-                      #if "maximum" not in var:
-                        #return True
-                      #if var["minimum"] > 1:
-                        #return True
-                      #if var["minimum"] == 0 and "maximum" in var and var["maximum"] == 1:
-                        #return True
-                    #if "maximum" in var:
-                      #if var["maximum"] > 1:
-                        #return True
-                    #return False
-                #elif "attributes" in var:
-                    #data_structure = var["attributes"]
-                #pass

--- a/docassemble/l4/data/questions/l4.yml
+++ b/docassemble/l4/data/questions/l4.yml
@@ -155,28 +155,28 @@ script: |
     $(".dasingleselect").change(function(){this.form.submit()})
   </script>
 ---
-mandatory: True
-code: |
-  def isList(agenda_item):
-    substr = "[ijklmn]*[0-9]*"
-    agenda_without_indices = re.sub("\[" + substr + "\]",'',agenda_item)
-    for i, item in enumerate(agenda_without_indices):
-        for var in data_structure:
-            if item == var['name']:
-                if i + 1 == len(agenda_without_indices):
-                    if "exactly" in var and var["exactly"] > 1:
-                        return True
-                    if "minimum" in var:
-                      if "maximum" not in var:
-                        return True
-                      if var["minimum"] > 1:
-                        return True
-                      if var["minimum"] == 0 and "maximum" in var and var["maximum"] == 1:
-                        return True
-                    if "maximum" in var:
-                      if var["maximum"] > 1:
-                        return True
-                    return False
-                elif "attributes" in var:
-                    data_structure = var["attributes"]
-                pass
+#mandatory: True
+#code: |
+  #def isList(agenda_item):
+    #substr = "[ijklmn]*[0-9]*"
+    #agenda_without_indices = re.sub("\[" + substr + "\]",'',agenda_item)
+    #for i, item in enumerate(agenda_without_indices):
+        #for var in data_structure:
+            #if item == var['name']:
+                #if i + 1 == len(agenda_without_indices):
+                    #if "exactly" in var and var["exactly"] > 1:
+                        #return True
+                    #if "minimum" in var:
+                      #if "maximum" not in var:
+                        #return True
+                      #if var["minimum"] > 1:
+                        #return True
+                      #if var["minimum"] == 0 and "maximum" in var and var["maximum"] == 1:
+                        #return True
+                    #if "maximum" in var:
+                      #if var["maximum"] > 1:
+                        #return True
+                    #return False
+                #elif "attributes" in var:
+                    #data_structure = var["attributes"]
+                #pass

--- a/docassemble/l4/intgen.py
+++ b/docassemble/l4/intgen.py
@@ -48,10 +48,10 @@ def generate_interview(LExSIS_source,scasp_source):
         output += "---\n"
 
     ## Include the Source File So It Can Be Accessed At RunTime
-    output += "variable name: data_structure\n"
-    output += "data:\n  "
-    output += '  '.join(yaml.dump(data_structure,width=1000000).splitlines(True))
-    output += "---\n"
+    # output += "variable name: data_structure\n"
+    # output += "data:\n  "
+    # output += '  '.join(yaml.dump(data_structure,width=1000000).splitlines(True))
+    # output += "---\n"
 
 
     ## Generate Objects Block


### PR DESCRIPTION
As requested, disabled the "variable name: data_structure" section within intGen.py, as well as removal of "isList" codeblock from l4.yml.

Tested it with the procedure listed in the demo procedure document. Interview completes with no issues. 